### PR TITLE
CLOG-1: refactoring usage of deprecated isNumeric() in Count()

### DIFF
--- a/cloveretl.component/src/org/jetel/component/aggregate/Count.java
+++ b/cloveretl.component/src/org/jetel/component/aggregate/Count.java
@@ -49,7 +49,7 @@ public class Count extends AggregateFunction {
 	 */
 	@Override
 	public void checkOutputFieldType(DataFieldMetadata outputField) throws AggregationException {
-		if (!outputField.isNumeric()) {
+		if (!outputField.getDataType().isNumeric()) {
 			throw new AggregationException(AggregateFunction.ERROR_NUMERIC);
 		}
 	}


### PR DESCRIPTION
Additional refactor related to deprecated isNumeric()